### PR TITLE
Url whitelist

### DIFF
--- a/01_sql_injection_rule.tf
+++ b/01_sql_injection_rule.tf
@@ -76,7 +76,7 @@ resource "aws_wafregional_sql_injection_match_set" "owasp_01_sql_injection_set" 
 }
 
 resource "aws_wafregional_rule" "owasp_01_sql_injection_rule" {
-  depends_on = [aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set]
+  depends_on = [aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set, aws_wafregional_byte_match_set.url_whitelist_string_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -87,6 +87,12 @@ resource "aws_wafregional_rule" "owasp_01_sql_injection_rule" {
     data_id = aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set.0.id
     negated = "false"
     type    = "SqlInjectionMatch"
+  }
+
+  predicate {
+    data_id = aws_wafregional_byte_match_set.url_whitelist_string_set.0.id
+    negated = "true"
+    type    = "ByteMatch"
   }
 }
 

--- a/03_xss_rule.tf
+++ b/03_xss_rule.tf
@@ -8,7 +8,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
 
   name = "${lower(var.waf_prefix)}-owasp-03-detect-xss-${random_id.this.0.hex}"
 
-  dynamic "xss_match_tuple" {
+  dynamic "xss_match_tuples" {
     for_each = var.disable_03_uri_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
@@ -19,7 +19,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuple" {
+  dynamic "xss_match_tuples" {
     for_each = var.disable_03_uri_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
@@ -30,7 +30,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuple" {
+  dynamic "xss_match_tuples" {
     for_each = var.disable_03_query_string_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
@@ -41,7 +41,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuple" {
+  dynamic "xss_match_tuples" {
     for_each = var.disable_03_query_string_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
@@ -52,7 +52,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuple" {
+  dynamic "xss_match_tuples" {
     for_each = var.disable_03_body_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
@@ -63,7 +63,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuple" {
+  dynamic "xss_match_tuples" {
     for_each = var.disable_03_body_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
@@ -74,7 +74,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuple" {
+  dynamic "xss_match_tuples" {
     for_each = var.disable_03_cookie_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
@@ -86,7 +86,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuple" {
+  dynamic "xss_match_tuples" {
     for_each = var.disable_03_cookie_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"

--- a/03_xss_rule.tf
+++ b/03_xss_rule.tf
@@ -100,7 +100,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
 }
 
 resource "aws_wafregional_rule" "owasp_03_xss_rule" {
-  depends_on = [aws_wafregional_xss_match_set.owasp_03_xss_set]
+  depends_on = [aws_wafregional_xss_match_set.owasp_03_xss_set, aws_wafregional_byte_match_set.url_whitelist_string_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -111,6 +111,12 @@ resource "aws_wafregional_rule" "owasp_03_xss_rule" {
     data_id = aws_wafregional_xss_match_set.owasp_03_xss_set.0.id
     negated = "false"
     type    = "XssMatch"
+  }
+
+  predicate {
+    data_id = aws_wafregional_byte_match_set.url_whitelist_string_set.0.id
+    negated = "true"
+    type    = "ByteMatch"
   }
 }
 

--- a/03_xss_rule.tf
+++ b/03_xss_rule.tf
@@ -8,7 +8,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
 
   name = "${lower(var.waf_prefix)}-owasp-03-detect-xss-${random_id.this.0.hex}"
 
-  dynamic "xss_match_tuples" {
+  dynamic "xss_match_tuple" {
     for_each = var.disable_03_uri_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
@@ -19,7 +19,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuples" {
+  dynamic "xss_match_tuple" {
     for_each = var.disable_03_uri_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
@@ -30,7 +30,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuples" {
+  dynamic "xss_match_tuple" {
     for_each = var.disable_03_query_string_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
@@ -41,7 +41,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuples" {
+  dynamic "xss_match_tuple" {
     for_each = var.disable_03_query_string_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
@@ -52,7 +52,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuples" {
+  dynamic "xss_match_tuple" {
     for_each = var.disable_03_body_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
@@ -63,7 +63,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuples" {
+  dynamic "xss_match_tuple" {
     for_each = var.disable_03_body_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
@@ -74,7 +74,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuples" {
+  dynamic "xss_match_tuple" {
     for_each = var.disable_03_cookie_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
@@ -86,7 +86,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
     }
   }
 
-  dynamic "xss_match_tuples" {
+  dynamic "xss_match_tuple" {
     for_each = var.disable_03_cookie_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ References
 | rule_09_ssi_action_type | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | string | `"BLOCK"` | No |
 
 ## Optional Inputs:  
+
 ### Variables to adjust size restriction
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
@@ -88,6 +89,13 @@ References
 | disable_04_uri_contains_url_path_after_html_decode | Disable the 'URI contains: '://' after decoding as HTML tags.' filter | bool | `false` | No |
 | disable_04_query_string_contains_url_path_after_url_decode | Disable the 'Query string contains: '://' after decoding as URL.' filter | bool | `false` | No |
 | disable_04_query_string_contains_url_path_after_html_decode | Disable the 'Query string contains: '://' after decoding as HTML tags.' filter | bool | `false` | No |
+
+### Variables to enable URL whitelist
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| enable_url_whitelist_string_match_set | Enable the 'URL whitelisting' filter. If enabled, provide values for `url_whitelist_uri_prefix` and `url_whitelist_url_host` | bool | `false` | No |
+| url_whitelist_uri_prefix | URI prefix for URL whitelisting. Required if `enable_url_whitelist_string_match_set` is set to `true` | string | `""` | Yes |
+| url_whitelist_url_host | Host for URL whitelisting. Required if `enable_url_whitelist_string_match_set` is set to `true` | string | `""` | Yes |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -200,3 +200,21 @@ variable "disable_04_query_string_contains_url_path_after_html_decode" {
   type        = bool
   description = "Disable the 'Query string contains: '://' after decoding as HTML tags.' filter"
 }
+
+variable "enable_url_whitelist_string_match_set" {
+  default     = false
+  type        = bool
+  description = "Enable the 'URL whitelisting' filter. If enabled, provide values for `url_whitelist_uri_prefix` and `url_whitelist_url_host`"
+}
+
+variable "url_whitelist_uri_prefix" {
+  default     = ""
+  type        = string
+  description = "URI prefix for URL whitelisting. Required if `enable_url_whitelist_string_match_set` is set to `true`"
+}
+
+variable "url_whitelist_url_host" {
+  default     = ""
+  type        = string
+  description = "Host for URL whitelisting. Required if `enable_url_whitelist_string_match_set` is set to `true`"
+}


### PR DESCRIPTION
- added string match set filter for url whitelisting that matches request header host and uri prefix
- apply this filter to Cross-site script (XSS) rule and Sql Injection Rule to allow request that matches this filter

Ref: https://docs.aws.amazon.com/solutions/latest/aws-waf-security-automations/considerations.html#xss-false-positives