### PR TITLE
Update to TF 0.15.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,14 +76,14 @@ resource "aws_wafregional_byte_match_set" "url_whitelist_string_set" {
 ## Regional - RuleGroup
 resource "aws_wafregional_rule_group" "owasp_top_10" {
   depends_on = [
-    "aws_wafregional_rule.owasp_01_sql_injection_rule",
-    "aws_wafregional_rule.owasp_02_auth_token_rule",
-    "aws_wafregional_rule.owasp_03_xss_rule",
-    "aws_wafregional_rule.owasp_04_paths_rule",
-    "aws_wafregional_rule.owasp_06_php_insecure_rule",
-    "aws_wafregional_rule.owasp_07_size_restriction_rule",
-    "aws_wafregional_rule.owasp_08_csrf_rule",
-    "aws_wafregional_rule.owasp_09_server_side_include_rule",
+    aws_wafregional_rule.owasp_01_sql_injection_rule,
+    aws_wafregional_rule.owasp_02_auth_token_rule,
+    aws_wafregional_rule.owasp_03_xss_rule,
+    aws_wafregional_rule.owasp_04_paths_rule,
+    aws_wafregional_rule.owasp_06_php_insecure_rule,
+    aws_wafregional_rule.owasp_07_size_restriction_rule,
+    aws_wafregional_rule.owasp_08_csrf_rule,
+    aws_wafregional_rule.owasp_09_server_side_include_rule,
   ]
 
   count = lower(var.create_rule_group) && lower(var.target_scope) == "regional" ? 1 : 0
@@ -175,14 +175,14 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
 ## Global - RuleGroup
 resource "aws_waf_rule_group" "owasp_top_10" {
   depends_on = [
-    "aws_waf_rule.owasp_01_sql_injection_rule",
-    "aws_waf_rule.owasp_02_auth_token_rule",
-    "aws_waf_rule.owasp_03_xss_rule",
-    "aws_waf_rule.owasp_04_paths_rule",
-    "aws_waf_rule.owasp_06_php_insecure_rule",
-    "aws_waf_rule.owasp_07_size_restriction_rule",
-    "aws_waf_rule.owasp_08_csrf_rule",
-    "aws_waf_rule.owasp_09_server_side_include_rule",
+    aws_waf_rule.owasp_01_sql_injection_rule,
+    aws_waf_rule.owasp_02_auth_token_rule,
+    aws_waf_rule.owasp_03_xss_rule,
+    aws_waf_rule.owasp_04_paths_rule,
+    aws_waf_rule.owasp_06_php_insecure_rule,
+    aws_waf_rule.owasp_07_size_restriction_rule,
+    aws_waf_rule.owasp_08_csrf_rule,
+    aws_waf_rule.owasp_09_server_side_include_rule,
   ]
 
   count = lower(var.create_rule_group) && lower(var.target_scope) == "global" ? 1 : 0

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,44 +1,44 @@
 output "rule_group_id" {
   description = "AWS WAF Rule Group which contains all rules for OWASP Top 10 protection."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule_group.owasp_top_10.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule_group.owasp_top_10.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule_group.owasp_top_10.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule_group.owasp_top_10.*.id, ["NOT_CREATED"]), "0")
 }
 
 output "rule_01_sql_injection_rule_id" {
   description = "AWS WAF Rule which mitigates SQL Injection Attacks."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_01_sql_injection_rule.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule.owasp_01_sql_injection_rule.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_01_sql_injection_rule.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule.owasp_01_sql_injection_rule.*.id, ["NOT_CREATED"]), "0")
 }
 
 output "rule_02_auth_token_rule_id" {
   description = "AWS WAF Rule which blacklists bad/hijacked JWT tokens or session IDs."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_02_auth_token_rule.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule.owasp_02_auth_token_rule.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_02_auth_token_rule.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule.owasp_02_auth_token_rule.*.id, ["NOT_CREATED"]), "0")
 }
 
 output "rule_03_xss_rule_id" {
   description = "AWS WAF Rule which mitigates Cross Site Scripting Attacks."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_03_xss_rule.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule.owasp_03_xss_rule.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_03_xss_rule.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule.owasp_03_xss_rule.*.id, ["NOT_CREATED"]), "0")
 }
 
 output "rule_04_paths_rule_id" {
   description = "AWS WAF Rule which mitigates Path Traversal, LFI, RFI."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_04_paths_rule.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule.owasp_04_paths_rule.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_04_paths_rule.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule.owasp_04_paths_rule.*.id, ["NOT_CREATED"]), "0")
 }
 
 output "rule_06_php_insecure_rule_id" {
   description = "AWS WAF Rule which mitigates PHP Specific Security Misconfigurations."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_06_php_insecure_rule.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule.owasp_06_php_insecure_rule.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_06_php_insecure_rule.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule.owasp_06_php_insecure_rule.*.id, ["NOT_CREATED"]), "0")
 }
 
 output "rule_07_size_restriction_rule_id" {
   description = "AWS WAF Rule which mitigates abnormal requests via size restrictions."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_07_size_restriction_rule.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule.owasp_07_size_restriction_rule.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_07_size_restriction_rule.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule.owasp_07_size_restriction_rule.*.id, ["NOT_CREATED"]), "0")
 }
 
 output "rule_08_csrf_rule_id" {
   description = "AWS WAF Rule which enforces the presence of CSRF token in request header."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_08_csrf_rule.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule.owasp_08_csrf_rule.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_08_csrf_rule.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule.owasp_08_csrf_rule.*.id, ["NOT_CREATED"]), "0")
 }
 
 output "rule_09_ssi_rule_id" {
   description = "AWS WAF Rule which blocks request patterns for webroot objects that shouldn't be directly accessible."
-  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_09_server_side_include_rule.*.id, list("NOT_CREATED")), "0") : element(concat(aws_waf_rule.owasp_09_server_side_include_rule.*.id, list("NOT_CREATED")), "0")
+  value       = lower(var.target_scope) == "regional" ? element(concat(aws_wafregional_rule.owasp_09_server_side_include_rule.*.id, ["NOT_CREATED"]), "0") : element(concat(aws_waf_rule.owasp_09_server_side_include_rule.*.id, ["NOT_CREATED"]), "0")
 }


### PR DESCRIPTION
### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
TF 0.15.x compatibility

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* No breaking changes - in fact their should be no changes to infrastructure at all from this change. It will simply work with TF 0.15.x now.

FEATURES:

* Support for TF 0.15.x
* Deprecate use of list() - no longer available was deprecated back at TF 0.12.x
* Fix resource quotation warnings

ENHANCEMENTS:

* None

BUG FIXES:

* None
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan
No changes. Infrastructure is up-to-date.
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
